### PR TITLE
Refactor for cross-platform and Added custom points per object command line argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# editor stuff
+.idea/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ python3.6 render_mitsuba2_pc.py chair.npy
 
 # It could also render a ply file
 python3.6 render_mitsuba2_pc.py chair.ply
+
+# Render with a different number of points per object
+python3.6 render_mitsuba2_pc chair.ply -n 2048
 ```
 
 All the outputs including the resulting JPG files will be saved in the directory of the input point cloud. The intermediate EXR/XML files will remain in the folder and has to be removed by the user. 

--- a/render_mitsuba2_pc.py
+++ b/render_mitsuba2_pc.py
@@ -1,3 +1,4 @@
+import argparse
 import numpy as np
 import sys, os, subprocess
 import OpenEXR
@@ -140,12 +141,8 @@ def ConvertEXRToJPG(exrfile, jpgfile):
     Image.merge("RGB", rgb8).save(jpgfile, "JPEG", quality=95)
 
 
-def main(argv):
-    if (len(argv) < 2):
-        print('filename to npy/ply is not passed as argument. terminated.')
-        return
-
-    pathToFile = argv[1]
+def main(args):
+    pathToFile = args.filename
 
     filename, file_extension = os.path.splitext(pathToFile)
     folder = os.path.dirname(pathToFile)
@@ -175,7 +172,7 @@ def main(argv):
     for pcli in range(0, pclTimeSize[0]):
         pcl = pclTime[pcli, :, :]
 
-        pcl = standardize_bbox(pcl, 2048)
+        pcl = standardize_bbox(pcl, args.num_points_per_object)
         pcl = pcl[:, [2, 0, 1]]
         pcl[:, 0] *= -1
         pcl[:, 2] += 0.0125
@@ -207,5 +204,12 @@ def main(argv):
         ConvertEXRToJPG(exrFile, png)
 
 
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filename", help="filename to npy/ply")
+    parser.add_argument("-n", "--num_points_per_object", type=int, default=2048)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main(sys.argv)
+    main(parse_args())

--- a/render_mitsuba2_pc.py
+++ b/render_mitsuba2_pc.py
@@ -188,20 +188,20 @@ def main(argv):
 
         xml_content = str.join('', xml_segments)
 
-        xmlFile = ("%s/%s_%02d.xml" % (folder, filename, pcli))
+        xmlFile = os.path.join(folder, f"{filename}_{pcli:02d}.xml")
 
         with open(xmlFile, 'w') as f:
             f.write(xml_content)
         f.close()
 
-        exrFile = ("%s/%s_%02d.exr" % (folder, filename, pcli))
+        exrFile = os.path.join(folder, f"{filename}_{pcli:02d}.exr")
         if (not os.path.exists(exrFile)):
             print(['Running Mitsuba, writing to: ', xmlFile])
             subprocess.run([PATH_TO_MITSUBA2, xmlFile])
         else:
             print('skipping rendering because the EXR file already exists')
 
-        png = ("%s/%s_%02d.jpg" % (folder, filename, pcli))
+        png = os.path.join(folder, f"{filename}_{pcli:02d}.jpg")
 
         print(['Converting EXR to JPG...'])
         ConvertEXRToJPG(exrFile, png)


### PR DESCRIPTION
## Description
Refactored the file paths to use os.path.join in order to work cross-platform.

Also refactored the command line handling to use argparse, and added a custom argument `num_ponts_per_object` so we can pass that argument too (the default is 2048, so it preserves the original behaviour).